### PR TITLE
[codex] add RTX 50 and RTX PRO GPU options

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,6 +260,16 @@
                     <label for="gpu-type">GPU Model:</label>
                     <select id="gpu-type" onchange="updateGPUSpecs();">
                         <option value="">Select GPU...</option>
+                        <optgroup label="NVIDIA RTX 50 Series">
+                            <option value="rtx5090" data-vram="32">RTX 5090 (32GB VRAM)</option>
+                            <option value="rtx5080" data-vram="16">RTX 5080 (16GB VRAM)</option>
+                            <option value="rtx5070ti" data-vram="16">RTX 5070 Ti (16GB VRAM)</option>
+                            <option value="rtx5070" data-vram="12">RTX 5070 (12GB VRAM)</option>
+                            <option value="rtx5060ti" data-vram="16">RTX 5060 Ti 16GB (16GB VRAM)</option>
+                            <option value="rtx5060ti8" data-vram="8">RTX 5060 Ti 8GB (8GB VRAM)</option>
+                            <option value="rtx5060" data-vram="8">RTX 5060 (8GB VRAM)</option>
+                            <option value="rtx5050" data-vram="8">RTX 5050 (8GB VRAM)</option>
+                        </optgroup>
                         <optgroup label="NVIDIA RTX 40 Series">
                             <option value="rtx4090" data-vram="24">RTX 4090 (24GB VRAM)</option>
                             <option value="rtx4080" data-vram="16">RTX 4080 (16GB VRAM)</option>
@@ -282,11 +292,15 @@
                             <option value="b200" data-vram="192">B200 (192GB HBM3e)</option>
                             <option value="v100" data-vram="32">V100 32GB (32GB VRAM)</option>
                             <option value="rtx6000" data-vram="48">RTX 6000 Ada (48GB VRAM)</option>
-                            <option value="rtxpro6000bw-ws" data-vram="96">RTX 6000 Pro Blackwell Workstation (96GB VRAM)</option>
-                            <option value="rtxpro6000bw-maxq" data-vram="96">RTX 6000 Pro Blackwell Max-Q (96GB VRAM)</option>
-                            <option value="rtxpro6000bw-server" data-vram="96">RTX 6000 Pro Blackwell Server (96GB VRAM)</option>
-                            <option value="rtxpro5000bw-48" data-vram="48">RTX 5000 Pro Blackwell (48GB VRAM)</option>
-                            <option value="rtxpro5000bw-72" data-vram="72">RTX 5000 Pro 72GB Blackwell (72GB VRAM)</option>
+                            <option value="rtxpro6000bw-ws" data-vram="96">RTX PRO 6000 Blackwell Workstation (96GB VRAM)</option>
+                            <option value="rtxpro6000bw-maxq" data-vram="96">RTX PRO 6000 Blackwell Max-Q Workstation (96GB VRAM)</option>
+                            <option value="rtxpro6000bw-server" data-vram="96">RTX PRO 6000 Blackwell Server (96GB VRAM)</option>
+                            <option value="rtxpro5000bw-48" data-vram="48">RTX PRO 5000 Blackwell (48GB VRAM)</option>
+                            <option value="rtxpro5000bw-72" data-vram="72">RTX PRO 5000 Blackwell 72GB (72GB VRAM)</option>
+                            <option value="rtxpro4500bw" data-vram="32">RTX PRO 4500 Blackwell Workstation (32GB VRAM)</option>
+                            <option value="rtxpro4000bw" data-vram="24">RTX PRO 4000 Blackwell (24GB VRAM)</option>
+                            <option value="rtxpro4000bw-sff" data-vram="24">RTX PRO 4000 Blackwell SFF (24GB VRAM)</option>
+                            <option value="rtxpro2000bw" data-vram="16">RTX PRO 2000 Blackwell (16GB VRAM)</option>
                         </optgroup>
                         <optgroup label="AMD Radeon">
                             <option value="rx7900xtx" data-vram="24">RX 7900 XTX (24GB VRAM)</option>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "GPU Memory Calculator for Self-Hosted LLM Inference",
   "main": "index.html",
   "scripts": {
+    "test": "node tests/gpu-catalog.test.js",
     "dev": "wrangler dev --port 8080 --local",
     "deploy": "wrangler deploy",
     "deploy:staging": "wrangler deploy --env staging",

--- a/selfhost-llm.js
+++ b/selfhost-llm.js
@@ -103,6 +103,16 @@ function getGPUBandwidth(gpuModel) {
     if (!gpuModel) return 0;
     
     const bandwidthMap = {
+        // RTX 50 Series
+        'rtx5090': 1792,
+        'rtx5080': 960,
+        'rtx5070ti': 896,
+        'rtx5070': 672,
+        'rtx5060ti': 448,
+        'rtx5060ti8': 448,
+        'rtx5060': 448,
+        'rtx5050': 320,
+        
         // RTX 40 Series
         'rtx4090': 1008,
         'rtx4080': 736,
@@ -130,6 +140,10 @@ function getGPUBandwidth(gpuModel) {
         'rtxpro6000bw-server': 1597,  // RTX PRO 6000 Blackwell Server
         'rtxpro5000bw-48': 1344,  // RTX PRO 5000 Blackwell 48GB
         'rtxpro5000bw-72': 1344,  // RTX PRO 5000 72GB Blackwell
+        'rtxpro4500bw': 896,  // RTX PRO 4500 Blackwell Workstation
+        'rtxpro4000bw': 672,  // RTX PRO 4000 Blackwell
+        'rtxpro4000bw-sff': 432,  // RTX PRO 4000 Blackwell SFF
+        'rtxpro2000bw': 288,  // RTX PRO 2000 Blackwell
         'l40s': 864,
         'l40': 864,
         'l4': 300,

--- a/tests/gpu-catalog.test.js
+++ b/tests/gpu-catalog.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const html = fs.readFileSync(path.join(rootDir, 'index.html'), 'utf8');
+const script = fs.readFileSync(path.join(rootDir, 'selfhost-llm.js'), 'utf8');
+
+const expectedGpus = [
+    { id: 'rtx5090', vram: '32', label: 'RTX 5090 (32GB VRAM)', bandwidth: 1792 },
+    { id: 'rtx5080', vram: '16', label: 'RTX 5080 (16GB VRAM)', bandwidth: 960 },
+    { id: 'rtx5070ti', vram: '16', label: 'RTX 5070 Ti (16GB VRAM)', bandwidth: 896 },
+    { id: 'rtx5070', vram: '12', label: 'RTX 5070 (12GB VRAM)', bandwidth: 672 },
+    { id: 'rtx5060ti', vram: '16', label: 'RTX 5060 Ti 16GB (16GB VRAM)', bandwidth: 448 },
+    { id: 'rtx5060ti8', vram: '8', label: 'RTX 5060 Ti 8GB (8GB VRAM)', bandwidth: 448 },
+    { id: 'rtx5060', vram: '8', label: 'RTX 5060 (8GB VRAM)', bandwidth: 448 },
+    { id: 'rtx5050', vram: '8', label: 'RTX 5050 (8GB VRAM)', bandwidth: 320 },
+    { id: 'rtxpro6000bw-ws', vram: '96', label: 'RTX PRO 6000 Blackwell Workstation (96GB VRAM)', bandwidth: 1792 },
+    { id: 'rtxpro6000bw-maxq', vram: '96', label: 'RTX PRO 6000 Blackwell Max-Q Workstation (96GB VRAM)', bandwidth: 1792 },
+    { id: 'rtxpro6000bw-server', vram: '96', label: 'RTX PRO 6000 Blackwell Server (96GB VRAM)', bandwidth: 1597 },
+    { id: 'rtxpro5000bw-48', vram: '48', label: 'RTX PRO 5000 Blackwell (48GB VRAM)', bandwidth: 1344 },
+    { id: 'rtxpro5000bw-72', vram: '72', label: 'RTX PRO 5000 Blackwell 72GB (72GB VRAM)', bandwidth: 1344 },
+    { id: 'rtxpro4500bw', vram: '32', label: 'RTX PRO 4500 Blackwell Workstation (32GB VRAM)', bandwidth: 896 },
+    { id: 'rtxpro4000bw', vram: '24', label: 'RTX PRO 4000 Blackwell (24GB VRAM)', bandwidth: 672 },
+    { id: 'rtxpro4000bw-sff', vram: '24', label: 'RTX PRO 4000 Blackwell SFF (24GB VRAM)', bandwidth: 432 },
+    { id: 'rtxpro2000bw', vram: '16', label: 'RTX PRO 2000 Blackwell (16GB VRAM)', bandwidth: 288 }
+];
+
+function parseGpuOptions(source) {
+    const options = new Map();
+    const optionPattern = /<option value="([^"]+)" data-vram="([^"]+)">([^<]+)<\/option>/g;
+    let match;
+
+    while ((match = optionPattern.exec(source)) !== null) {
+        options.set(match[1], {
+            vram: match[2],
+            label: match[3]
+        });
+    }
+
+    return options;
+}
+
+function parseBandwidths(source) {
+    const mapMatch = source.match(/const bandwidthMap = \{([\s\S]*?)\n\s*\};/);
+    assert.ok(mapMatch, 'getGPUBandwidth should define a bandwidthMap object');
+
+    const bandwidths = new Map();
+    const entryPattern = /'([^']+)':\s*([0-9.]+)/g;
+    let match;
+
+    while ((match = entryPattern.exec(mapMatch[1])) !== null) {
+        bandwidths.set(match[1], Number(match[2]));
+    }
+
+    return bandwidths;
+}
+
+assert.ok(
+    html.includes('<optgroup label="NVIDIA RTX 50 Series">'),
+    'GPU selector should include an NVIDIA RTX 50 Series group'
+);
+
+const options = parseGpuOptions(html);
+const bandwidths = parseBandwidths(script);
+
+for (const gpu of expectedGpus) {
+    assert.ok(options.has(gpu.id), `${gpu.id} should be available in the GPU selector`);
+    assert.strictEqual(options.get(gpu.id).vram, gpu.vram, `${gpu.id} should have ${gpu.vram}GB VRAM`);
+    assert.strictEqual(options.get(gpu.id).label, gpu.label, `${gpu.id} should use the expected display label`);
+    assert.strictEqual(bandwidths.get(gpu.id), gpu.bandwidth, `${gpu.id} should have ${gpu.bandwidth} GB/s bandwidth`);
+}


### PR DESCRIPTION
## Summary
- Adds NVIDIA RTX 50 Series desktop GPU choices, including each available VRAM configuration.
- Adds missing RTX PRO Blackwell desktop/workstation/server options for 2000, 4000, 4000 SFF, 4500, 5000, and 6000 variants.
- Adds bandwidth entries and a catalog test that checks selector VRAM labels and performance bandwidth coverage.

## Why
Issue #2 reports that RTX 5000-series consumer cards were missing. This also checks and fills the requested RTX PRO 2000/4000/5000/6000 memory configurations.

## Test Plan
- [x] npm test

Refs #2
