### PR TITLE
[codex] update recent model catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ The calculator automatically detects and handles MoE models differently:
 
 The calculator includes memory profiles for 100+ models from all major providers:
 
-### Latest 2025 Models
-- **Moonshot AI Kimi**: K2 Base/Instruct (1T params, 32B active)
-- **Alibaba Qwen 3**: 270M to 235B including MoE variants
-- **DeepSeek V3/R1**: Latest reasoning models with distilled versions
-- **Zhipu AI GLM**: ChatGLM to GLM-4.5 including MoE models
+### Latest Models
+- **Moonshot AI Kimi**: K2 through K2.6 plus Kimi Linear 48B-A3B variants
+- **Alibaba Qwen 3**: Dense, MoE, 2507, Coder, and Next variants up to 480B total parameters
+- **DeepSeek V4/V3/R1**: V4 Pro/Flash, V3.2, V3.1 Terminus, R1-0528, and distilled versions
+- **Z.ai GLM**: ChatGLM through GLM-5.1 including GLM-4.5/4.6/4.7/5 MoE models
+- **IBM Granite**: Granite 4.0 hybrid/dense and Granite 4.1 long-context models
 - **Google Gemma 3**: 270M to 27B with multimodal capabilities
 - **Mistral Codestral**: Latest code-specialized models
 

--- a/index.html
+++ b/index.html
@@ -368,12 +368,18 @@
                             <option value="110" data-memory="220" data-quant="0.5">Qwen 110B (~220GB)</option>
                         </optgroup>
                         <optgroup label="Alibaba Qwen 3 (2025)">
+                            <option value="0.6" data-memory="1.2" data-quant="1.0">Qwen3 0.6B (~1.2GB)</option>
+                            <option value="1.7" data-memory="3.4" data-quant="1.0">Qwen3 1.7B (~3.4GB)</option>
                             <option value="4" data-memory="8" data-quant="1.0">Qwen3 4B (~8GB)</option>
                             <option value="8" data-memory="16" data-quant="1.0">Qwen3 8B (~16GB)</option>
                             <option value="14" data-memory="28" data-quant="1.0">Qwen3 14B (~28GB)</option>
                             <option value="32" data-memory="64" data-quant="1.0">Qwen3 32B (~64GB)</option>
                             <option value="3" data-memory="60" data-active-memory="6" data-quant="1.0">Qwen3 30B-A3B MoE (~60GB total, ~6GB active)</option>
                             <option value="22" data-memory="470" data-active-memory="44" data-quant="0.5">Qwen3 235B-A22B MoE (~470GB total, ~44GB active)</option>
+                            <option value="3.3" data-memory="61" data-active-memory="6.6" data-quant="1.0">Qwen3 30B-A3B Instruct 2507 (~61GB total, ~6.6GB active)</option>
+                            <option value="3.3" data-memory="61" data-active-memory="6.6" data-quant="1.0">Qwen3 30B-A3B Thinking 2507 (~61GB total, ~6.6GB active)</option>
+                            <option value="22" data-memory="470" data-active-memory="44" data-quant="0.5">Qwen3 235B-A22B Instruct 2507 (~470GB total, ~44GB active)</option>
+                            <option value="22" data-memory="470" data-active-memory="44" data-quant="0.5">Qwen3 235B-A22B Thinking 2507 (~470GB total, ~44GB active)</option>
                         </optgroup>
                         <optgroup label="Alibaba Qwen 3.5 (2026)">
                             <option value="27" data-memory="54" data-quant="1.0">Qwen3.5 27B (~54GB)</option>
@@ -387,6 +393,9 @@
                             <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2 Thinking 1T (~2000GB total, ~64GB active)</option>
                             <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2-Instruct-0905 1T (~2000GB total, ~64GB active)</option>
                             <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2.5 1T (~2000GB total, ~64GB active)</option>
+                            <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2.6 1T (~2000GB total, ~64GB active)</option>
+                            <option value="3" data-memory="96" data-active-memory="6" data-quant="1.0">Kimi Linear 48B-A3B Base (~96GB total, ~6GB active)</option>
+                            <option value="3" data-memory="96" data-active-memory="6" data-quant="1.0">Kimi Linear 48B-A3B Instruct (~96GB total, ~6GB active)</option>
                         </optgroup>
                         <optgroup label="MiniMax (2025-2026)">
                             <option value="46" data-memory="912" data-active-memory="92" data-quant="0.5">MiniMax-M1-80k 456B (~912GB total, ~92GB active)</option>
@@ -406,6 +415,12 @@
                             <option value="1.5" data-memory="3" data-quant="1.0">Qwen-Coder 1.5B (~3GB)</option>
                             <option value="7" data-memory="14" data-quant="1.0">Qwen-Coder 7B (~14GB)</option>
                             <option value="32" data-memory="64" data-quant="0.5">Qwen-Coder 32B (~64GB)</option>
+                            <option value="3.3" data-memory="61" data-active-memory="6.6" data-quant="1.0">Qwen3-Coder 30B-A3B Instruct (~61GB total, ~6.6GB active)</option>
+                            <option value="35" data-memory="960" data-active-memory="70" data-quant="0.5">Qwen3-Coder 480B-A35B Instruct (~960GB total, ~70GB active)</option>
+                        </optgroup>
+                        <optgroup label="Qwen 3 Next">
+                            <option value="3" data-memory="160" data-active-memory="6" data-quant="1.0">Qwen3-Next 80B-A3B Instruct (~160GB total, ~6GB active)</option>
+                            <option value="3" data-memory="160" data-active-memory="6" data-quant="1.0">Qwen3-Next 80B-A3B Thinking (~160GB total, ~6GB active)</option>
                         </optgroup>
                         <optgroup label="DeepSeek">
                             <option value="7" data-memory="14" data-quant="1.0">DeepSeek 7B (~14GB)</option>
@@ -413,9 +428,17 @@
                             <option value="67" data-memory="134" data-quant="0.5">DeepSeek 67B (~134GB)</option>
                             <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3 671B (~1342GB total, ~74GB active)</option>
                             <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3.1 671B (~1342GB total, ~74GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3.1 Terminus 671B (~1342GB total, ~74GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3.2-Exp 671B (~1342GB total, ~74GB active)</option>
                             <option value="37" data-memory="1370" data-active-memory="74" data-quant="0.5">DeepSeek V3.2 685B (~1370GB total, ~74GB active)</option>
                             <option value="37" data-memory="1370" data-active-memory="74" data-quant="0.5">DeepSeek V3.2-Speciale 685B (~1370GB total, ~74GB active)</option>
-                            <option value="21" data-memory="472" data-active-memory="42" data-quant="0.5">DeepSeek R1 236B (~472GB total, ~42GB active)</option>
+                            <option value="13" data-memory="568" data-active-memory="26" data-quant="0.5">DeepSeek V4 Flash Base 284B (~568GB total, ~26GB active)</option>
+                            <option value="13" data-memory="568" data-active-memory="26" data-quant="0.5">DeepSeek V4 Flash 284B (~568GB total, ~26GB active)</option>
+                            <option value="49" data-memory="3200" data-active-memory="98" data-quant="0.5">DeepSeek V4 Pro Base 1.6T (~3200GB total, ~98GB active)</option>
+                            <option value="49" data-memory="3200" data-active-memory="98" data-quant="0.5">DeepSeek V4 Pro 1.6T (~3200GB total, ~98GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek R1 671B (~1342GB total, ~74GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek R1-0528 671B (~1342GB total, ~74GB active)</option>
+                            <option value="8" data-memory="16" data-quant="1.0">DeepSeek R1-0528-Qwen3-8B (~16GB)</option>
                             <option value="1.5" data-memory="3" data-quant="1.0">DeepSeek R1 1.5B Distilled (~3GB)</option>
                             <option value="7" data-memory="14" data-quant="1.0">DeepSeek R1 7B Distilled (~14GB)</option>
                             <option value="32" data-memory="64" data-quant="1.0">DeepSeek R1 32B Distilled (~64GB)</option>
@@ -458,8 +481,8 @@
                             <option value="6.2" data-memory="12" data-quant="1.0">ChatGLM2-6B (~12GB)</option>
                             <option value="9" data-memory="18" data-quant="1.0">GLM-4-9B (~18GB)</option>
                             <option value="32" data-memory="64" data-quant="1.0">GLM-4-32B (~64GB)</option>
-                            <option value="12" data-memory="106" data-active-memory="24" data-quant="0.5">GLM-4.5-Air MoE (~106GB total, ~24GB active)</option>
-                            <option value="32" data-memory="355" data-active-memory="64" data-quant="0.5">GLM-4.5 MoE (~355GB total, ~64GB active)</option>
+                            <option value="12" data-memory="212" data-active-memory="24" data-quant="0.5">GLM-4.5-Air MoE (~212GB total, ~24GB active)</option>
+                            <option value="32" data-memory="710" data-active-memory="64" data-quant="0.5">GLM-4.5 MoE (~710GB total, ~64GB active)</option>
                         </optgroup>
                         <optgroup label="Zhipu AI GLM 4.6 (2025)">
                             <option value="32" data-memory="710" data-active-memory="64" data-quant="0.5">GLM-4.6 355B MoE (~710GB total, ~64GB active)</option>
@@ -467,8 +490,12 @@
                             <option value="9" data-memory="18" data-quant="1.0">GLM-4.6V-Flash 9B (~18GB)</option>
                         </optgroup>
                         <optgroup label="Zhipu AI GLM 4.7 (2025-2026)">
-                            <option value="32" data-memory="710" data-active-memory="64" data-quant="0.5">GLM-4.7 355B-A32B MoE (~710GB total, ~64GB active)</option>
+                            <option value="32" data-memory="716" data-active-memory="64" data-quant="0.5">GLM-4.7 358B-A32B MoE (~716GB total, ~64GB active)</option>
                             <option value="3" data-memory="60" data-active-memory="6" data-quant="1.0">GLM-4.7-Flash 30B-A3B MoE (~60GB total, ~6GB active)</option>
+                        </optgroup>
+                        <optgroup label="Zhipu AI GLM 5 (2026)">
+                            <option value="40" data-memory="1508" data-active-memory="80" data-quant="0.5">GLM-5 754B-A40B MoE (~1508GB total, ~80GB active)</option>
+                            <option value="40" data-memory="1508" data-active-memory="80" data-quant="0.5">GLM-5.1 754B-A40B MoE (~1508GB total, ~80GB active)</option>
                         </optgroup>
                         <optgroup label="Google Gemma">
                             <option value="2" data-memory="4" data-quant="1.0">Gemma 2B (~4GB)</option>
@@ -490,9 +517,15 @@
                         <optgroup label="IBM Granite 4.0 (2025)">
                             <option value="0.35" data-memory="0.7" data-quant="1.0">Granite 4.0 H 350M (~0.7GB)</option>
                             <option value="1.5" data-memory="3" data-quant="1.0">Granite 4.0 H 1B (~3GB)</option>
+                            <option value="3" data-memory="6" data-quant="1.0">Granite 4.0 Micro 3B (~6GB)</option>
                             <option value="3" data-memory="6" data-quant="1.0">Granite 4.0 H-Micro 3B (~6GB)</option>
                             <option value="1" data-memory="14" data-active-memory="2" data-quant="1.0">Granite 4.0 H-Tiny 7B (~14GB total, ~2GB active)</option>
                             <option value="9" data-memory="64" data-active-memory="18" data-quant="1.0">Granite 4.0 H-Small 32B (~64GB total, ~18GB active)</option>
+                        </optgroup>
+                        <optgroup label="IBM Granite 4.1 (2026)">
+                            <option value="3" data-memory="6" data-quant="1.0">Granite 4.1 3B (~6GB)</option>
+                            <option value="8" data-memory="16" data-quant="1.0">Granite 4.1 8B (~16GB)</option>
+                            <option value="30" data-memory="60" data-quant="0.5">Granite 4.1 30B (~60GB)</option>
                         </optgroup>
                         <optgroup label="AI2 OLMo 2">
                             <option value="1" data-memory="2" data-quant="1.0">OLMo 2 1B (~2GB)</option>

--- a/mac/index.html
+++ b/mac/index.html
@@ -401,12 +401,18 @@
                             <option value="110" data-memory="220" data-quant="0.5">Qwen 110B (~220GB)</option>
                         </optgroup>
                         <optgroup label="Alibaba Qwen 3 (2025)">
+                            <option value="0.6" data-memory="1.2" data-quant="1.0">Qwen3 0.6B (~1.2GB)</option>
+                            <option value="1.7" data-memory="3.4" data-quant="1.0">Qwen3 1.7B (~3.4GB)</option>
                             <option value="4" data-memory="8" data-quant="1.0">Qwen3 4B (~8GB)</option>
                             <option value="8" data-memory="16" data-quant="1.0">Qwen3 8B (~16GB)</option>
                             <option value="14" data-memory="28" data-quant="1.0">Qwen3 14B (~28GB)</option>
                             <option value="32" data-memory="64" data-quant="1.0">Qwen3 32B (~64GB)</option>
                             <option value="3" data-memory="60" data-active-memory="6" data-quant="1.0">Qwen3 30B-A3B MoE (~60GB total, ~6GB active)</option>
                             <option value="22" data-memory="470" data-active-memory="44" data-quant="0.5">Qwen3 235B-A22B MoE (~470GB total, ~44GB active)</option>
+                            <option value="3.3" data-memory="61" data-active-memory="6.6" data-quant="1.0">Qwen3 30B-A3B Instruct 2507 (~61GB total, ~6.6GB active)</option>
+                            <option value="3.3" data-memory="61" data-active-memory="6.6" data-quant="1.0">Qwen3 30B-A3B Thinking 2507 (~61GB total, ~6.6GB active)</option>
+                            <option value="22" data-memory="470" data-active-memory="44" data-quant="0.5">Qwen3 235B-A22B Instruct 2507 (~470GB total, ~44GB active)</option>
+                            <option value="22" data-memory="470" data-active-memory="44" data-quant="0.5">Qwen3 235B-A22B Thinking 2507 (~470GB total, ~44GB active)</option>
                         </optgroup>
                         <optgroup label="Alibaba Qwen 3.5 (2026)">
                             <option value="27" data-memory="54" data-quant="1.0">Qwen3.5 27B (~54GB)</option>
@@ -420,6 +426,9 @@
                             <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2 Thinking 1T (~2000GB total, ~64GB active)</option>
                             <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2-Instruct-0905 1T (~2000GB total, ~64GB active)</option>
                             <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2.5 1T (~2000GB total, ~64GB active)</option>
+                            <option value="32" data-memory="2000" data-active-memory="64" data-quant="0.5">Kimi K2.6 1T (~2000GB total, ~64GB active)</option>
+                            <option value="3" data-memory="96" data-active-memory="6" data-quant="1.0">Kimi Linear 48B-A3B Base (~96GB total, ~6GB active)</option>
+                            <option value="3" data-memory="96" data-active-memory="6" data-quant="1.0">Kimi Linear 48B-A3B Instruct (~96GB total, ~6GB active)</option>
                         </optgroup>
                         <optgroup label="MiniMax (2025-2026)">
                             <option value="46" data-memory="912" data-active-memory="92" data-quant="0.5">MiniMax-M1-80k 456B (~912GB total, ~92GB active)</option>
@@ -439,6 +448,12 @@
                             <option value="1.5" data-memory="3" data-quant="1.0">Qwen-Coder 1.5B (~3GB)</option>
                             <option value="7" data-memory="14" data-quant="1.0">Qwen-Coder 7B (~14GB)</option>
                             <option value="32" data-memory="64" data-quant="0.5">Qwen-Coder 32B (~64GB)</option>
+                            <option value="3.3" data-memory="61" data-active-memory="6.6" data-quant="1.0">Qwen3-Coder 30B-A3B Instruct (~61GB total, ~6.6GB active)</option>
+                            <option value="35" data-memory="960" data-active-memory="70" data-quant="0.5">Qwen3-Coder 480B-A35B Instruct (~960GB total, ~70GB active)</option>
+                        </optgroup>
+                        <optgroup label="Qwen 3 Next">
+                            <option value="3" data-memory="160" data-active-memory="6" data-quant="1.0">Qwen3-Next 80B-A3B Instruct (~160GB total, ~6GB active)</option>
+                            <option value="3" data-memory="160" data-active-memory="6" data-quant="1.0">Qwen3-Next 80B-A3B Thinking (~160GB total, ~6GB active)</option>
                         </optgroup>
                         <optgroup label="DeepSeek">
                             <option value="7" data-memory="14" data-quant="1.0">DeepSeek 7B (~14GB)</option>
@@ -446,9 +461,17 @@
                             <option value="67" data-memory="134" data-quant="0.5">DeepSeek 67B (~134GB)</option>
                             <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3 671B (~1342GB total, ~74GB active)</option>
                             <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3.1 671B (~1342GB total, ~74GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3.1 Terminus 671B (~1342GB total, ~74GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek V3.2-Exp 671B (~1342GB total, ~74GB active)</option>
                             <option value="37" data-memory="1370" data-active-memory="74" data-quant="0.5">DeepSeek V3.2 685B (~1370GB total, ~74GB active)</option>
                             <option value="37" data-memory="1370" data-active-memory="74" data-quant="0.5">DeepSeek V3.2-Speciale 685B (~1370GB total, ~74GB active)</option>
-                            <option value="21" data-memory="472" data-active-memory="42" data-quant="0.5">DeepSeek R1 236B (~472GB total, ~42GB active)</option>
+                            <option value="13" data-memory="568" data-active-memory="26" data-quant="0.5">DeepSeek V4 Flash Base 284B (~568GB total, ~26GB active)</option>
+                            <option value="13" data-memory="568" data-active-memory="26" data-quant="0.5">DeepSeek V4 Flash 284B (~568GB total, ~26GB active)</option>
+                            <option value="49" data-memory="3200" data-active-memory="98" data-quant="0.5">DeepSeek V4 Pro Base 1.6T (~3200GB total, ~98GB active)</option>
+                            <option value="49" data-memory="3200" data-active-memory="98" data-quant="0.5">DeepSeek V4 Pro 1.6T (~3200GB total, ~98GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek R1 671B (~1342GB total, ~74GB active)</option>
+                            <option value="37" data-memory="1342" data-active-memory="74" data-quant="0.5">DeepSeek R1-0528 671B (~1342GB total, ~74GB active)</option>
+                            <option value="8" data-memory="16" data-quant="1.0">DeepSeek R1-0528-Qwen3-8B (~16GB)</option>
                             <option value="1.5" data-memory="3" data-quant="1.0">DeepSeek R1 1.5B Distilled (~3GB)</option>
                             <option value="7" data-memory="14" data-quant="1.0">DeepSeek R1 7B Distilled (~14GB)</option>
                             <option value="32" data-memory="64" data-quant="1.0">DeepSeek R1 32B Distilled (~64GB)</option>
@@ -491,8 +514,8 @@
                             <option value="6.2" data-memory="12" data-quant="1.0">ChatGLM2-6B (~12GB)</option>
                             <option value="9" data-memory="18" data-quant="1.0">GLM-4-9B (~18GB)</option>
                             <option value="32" data-memory="64" data-quant="1.0">GLM-4-32B (~64GB)</option>
-                            <option value="12" data-memory="106" data-active-memory="24" data-quant="0.5">GLM-4.5-Air MoE (~106GB total, ~24GB active)</option>
-                            <option value="32" data-memory="355" data-active-memory="64" data-quant="0.5">GLM-4.5 MoE (~355GB total, ~64GB active)</option>
+                            <option value="12" data-memory="212" data-active-memory="24" data-quant="0.5">GLM-4.5-Air MoE (~212GB total, ~24GB active)</option>
+                            <option value="32" data-memory="710" data-active-memory="64" data-quant="0.5">GLM-4.5 MoE (~710GB total, ~64GB active)</option>
                         </optgroup>
                         <optgroup label="Zhipu AI GLM 4.6 (2025)">
                             <option value="32" data-memory="710" data-active-memory="64" data-quant="0.5">GLM-4.6 355B MoE (~710GB total, ~64GB active)</option>
@@ -500,8 +523,12 @@
                             <option value="9" data-memory="18" data-quant="1.0">GLM-4.6V-Flash 9B (~18GB)</option>
                         </optgroup>
                         <optgroup label="Zhipu AI GLM 4.7 (2025-2026)">
-                            <option value="32" data-memory="710" data-active-memory="64" data-quant="0.5">GLM-4.7 355B-A32B MoE (~710GB total, ~64GB active)</option>
+                            <option value="32" data-memory="716" data-active-memory="64" data-quant="0.5">GLM-4.7 358B-A32B MoE (~716GB total, ~64GB active)</option>
                             <option value="3" data-memory="60" data-active-memory="6" data-quant="1.0">GLM-4.7-Flash 30B-A3B MoE (~60GB total, ~6GB active)</option>
+                        </optgroup>
+                        <optgroup label="Zhipu AI GLM 5 (2026)">
+                            <option value="40" data-memory="1508" data-active-memory="80" data-quant="0.5">GLM-5 754B-A40B MoE (~1508GB total, ~80GB active)</option>
+                            <option value="40" data-memory="1508" data-active-memory="80" data-quant="0.5">GLM-5.1 754B-A40B MoE (~1508GB total, ~80GB active)</option>
                         </optgroup>
                         <optgroup label="Google Gemma">
                             <option value="2" data-memory="4" data-quant="1.0">Gemma 2B (~4GB)</option>
@@ -523,9 +550,15 @@
                         <optgroup label="IBM Granite 4.0 (2025)">
                             <option value="0.35" data-memory="0.7" data-quant="1.0">Granite 4.0 H 350M (~0.7GB)</option>
                             <option value="1.5" data-memory="3" data-quant="1.0">Granite 4.0 H 1B (~3GB)</option>
+                            <option value="3" data-memory="6" data-quant="1.0">Granite 4.0 Micro 3B (~6GB)</option>
                             <option value="3" data-memory="6" data-quant="1.0">Granite 4.0 H-Micro 3B (~6GB)</option>
                             <option value="1" data-memory="14" data-active-memory="2" data-quant="1.0">Granite 4.0 H-Tiny 7B (~14GB total, ~2GB active)</option>
                             <option value="9" data-memory="64" data-active-memory="18" data-quant="1.0">Granite 4.0 H-Small 32B (~64GB total, ~18GB active)</option>
+                        </optgroup>
+                        <optgroup label="IBM Granite 4.1 (2026)">
+                            <option value="3" data-memory="6" data-quant="1.0">Granite 4.1 3B (~6GB)</option>
+                            <option value="8" data-memory="16" data-quant="1.0">Granite 4.1 8B (~16GB)</option>
+                            <option value="30" data-memory="60" data-quant="0.5">Granite 4.1 30B (~60GB)</option>
                         </optgroup>
                         <optgroup label="AI2 OLMo 2">
                             <option value="1" data-memory="2" data-quant="1.0">OLMo 2 1B (~2GB)</option>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GPU Memory Calculator for Self-Hosted LLM Inference",
   "main": "index.html",
   "scripts": {
-    "test": "node tests/gpu-catalog.test.js",
+    "test": "node tests/gpu-catalog.test.js && node tests/model-catalog.test.js",
     "dev": "wrangler dev --port 8080 --local",
     "deploy": "wrangler deploy",
     "deploy:staging": "wrangler deploy --env staging",

--- a/tests/model-catalog.test.js
+++ b/tests/model-catalog.test.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const catalogFiles = [
+    path.join(rootDir, 'index.html'),
+    path.join(rootDir, 'mac/index.html')
+];
+
+const expectedModels = [
+    { label: 'Qwen3 0.6B (~1.2GB)', value: '0.6', memory: '1.2', quant: '1.0' },
+    { label: 'Qwen3 1.7B (~3.4GB)', value: '1.7', memory: '3.4', quant: '1.0' },
+    { label: 'Qwen3 30B-A3B Instruct 2507 (~61GB total, ~6.6GB active)', value: '3.3', memory: '61', activeMemory: '6.6', quant: '1.0' },
+    { label: 'Qwen3 30B-A3B Thinking 2507 (~61GB total, ~6.6GB active)', value: '3.3', memory: '61', activeMemory: '6.6', quant: '1.0' },
+    { label: 'Qwen3 235B-A22B Instruct 2507 (~470GB total, ~44GB active)', value: '22', memory: '470', activeMemory: '44', quant: '0.5' },
+    { label: 'Qwen3 235B-A22B Thinking 2507 (~470GB total, ~44GB active)', value: '22', memory: '470', activeMemory: '44', quant: '0.5' },
+    { label: 'Qwen3-Coder 30B-A3B Instruct (~61GB total, ~6.6GB active)', value: '3.3', memory: '61', activeMemory: '6.6', quant: '1.0' },
+    { label: 'Qwen3-Coder 480B-A35B Instruct (~960GB total, ~70GB active)', value: '35', memory: '960', activeMemory: '70', quant: '0.5' },
+    { label: 'Qwen3-Next 80B-A3B Instruct (~160GB total, ~6GB active)', value: '3', memory: '160', activeMemory: '6', quant: '1.0' },
+    { label: 'Qwen3-Next 80B-A3B Thinking (~160GB total, ~6GB active)', value: '3', memory: '160', activeMemory: '6', quant: '1.0' },
+    { label: 'Kimi K2.6 1T (~2000GB total, ~64GB active)', value: '32', memory: '2000', activeMemory: '64', quant: '0.5' },
+    { label: 'Kimi Linear 48B-A3B Base (~96GB total, ~6GB active)', value: '3', memory: '96', activeMemory: '6', quant: '1.0' },
+    { label: 'Kimi Linear 48B-A3B Instruct (~96GB total, ~6GB active)', value: '3', memory: '96', activeMemory: '6', quant: '1.0' },
+    { label: 'DeepSeek V3.1 Terminus 671B (~1342GB total, ~74GB active)', value: '37', memory: '1342', activeMemory: '74', quant: '0.5' },
+    { label: 'DeepSeek V3.2-Exp 671B (~1342GB total, ~74GB active)', value: '37', memory: '1342', activeMemory: '74', quant: '0.5' },
+    { label: 'DeepSeek V4 Flash Base 284B (~568GB total, ~26GB active)', value: '13', memory: '568', activeMemory: '26', quant: '0.5' },
+    { label: 'DeepSeek V4 Flash 284B (~568GB total, ~26GB active)', value: '13', memory: '568', activeMemory: '26', quant: '0.5' },
+    { label: 'DeepSeek V4 Pro Base 1.6T (~3200GB total, ~98GB active)', value: '49', memory: '3200', activeMemory: '98', quant: '0.5' },
+    { label: 'DeepSeek V4 Pro 1.6T (~3200GB total, ~98GB active)', value: '49', memory: '3200', activeMemory: '98', quant: '0.5' },
+    { label: 'DeepSeek R1 671B (~1342GB total, ~74GB active)', value: '37', memory: '1342', activeMemory: '74', quant: '0.5' },
+    { label: 'DeepSeek R1-0528 671B (~1342GB total, ~74GB active)', value: '37', memory: '1342', activeMemory: '74', quant: '0.5' },
+    { label: 'DeepSeek R1-0528-Qwen3-8B (~16GB)', value: '8', memory: '16', quant: '1.0' },
+    { label: 'GLM-4.5-Air MoE (~212GB total, ~24GB active)', value: '12', memory: '212', activeMemory: '24', quant: '0.5' },
+    { label: 'GLM-4.5 MoE (~710GB total, ~64GB active)', value: '32', memory: '710', activeMemory: '64', quant: '0.5' },
+    { label: 'GLM-4.7 358B-A32B MoE (~716GB total, ~64GB active)', value: '32', memory: '716', activeMemory: '64', quant: '0.5' },
+    { label: 'GLM-5 754B-A40B MoE (~1508GB total, ~80GB active)', value: '40', memory: '1508', activeMemory: '80', quant: '0.5' },
+    { label: 'GLM-5.1 754B-A40B MoE (~1508GB total, ~80GB active)', value: '40', memory: '1508', activeMemory: '80', quant: '0.5' },
+    { label: 'Granite 4.0 Micro 3B (~6GB)', value: '3', memory: '6', quant: '1.0' },
+    { label: 'Granite 4.1 3B (~6GB)', value: '3', memory: '6', quant: '1.0' },
+    { label: 'Granite 4.1 8B (~16GB)', value: '8', memory: '16', quant: '1.0' },
+    { label: 'Granite 4.1 30B (~60GB)', value: '30', memory: '60', quant: '0.5' }
+];
+
+function parseModelOptions(source) {
+    const options = new Map();
+    const optionPattern = /<option value="([^"]+)" data-memory="([^"]+)"(?: data-active-memory="([^"]+)")? data-quant="([^"]+)">([^<]+)<\/option>/g;
+    let match;
+
+    while ((match = optionPattern.exec(source)) !== null) {
+        options.set(match[5], {
+            value: match[1],
+            memory: match[2],
+            activeMemory: match[3],
+            quant: match[4]
+        });
+    }
+
+    return options;
+}
+
+for (const file of catalogFiles) {
+    const source = fs.readFileSync(file, 'utf8');
+    const options = parseModelOptions(source);
+    const relativePath = path.relative(rootDir, file);
+
+    for (const model of expectedModels) {
+        assert.ok(options.has(model.label), `${relativePath} should include ${model.label}`);
+        const option = options.get(model.label);
+        assert.strictEqual(option.value, model.value, `${relativePath} ${model.label} should use value ${model.value}`);
+        assert.strictEqual(option.memory, model.memory, `${relativePath} ${model.label} should use ${model.memory}GB total memory`);
+        assert.strictEqual(option.activeMemory, model.activeMemory, `${relativePath} ${model.label} should use expected active memory`);
+        assert.strictEqual(option.quant, model.quant, `${relativePath} ${model.label} should use default quant ${model.quant}`);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds recent GLM, Kimi, Qwen, DeepSeek, and Granite model options to both GPU and Mac calculators.
- Corrects stale MoE memory metadata for GLM and DeepSeek entries.
- Adds model catalog tests so key recent entries stay present in both selectors.

## Test Plan
- [x] npm test
